### PR TITLE
Generalize encoders' call

### DIFF
--- a/chemspace/Encoders.py
+++ b/chemspace/Encoders.py
@@ -7,7 +7,7 @@ from transformers import (AutoConfig,
                           AutoModel,
                           AutoModelForMaskedLM,
                           BertForPreTraining)
-from typing import Any
+from typing import Union
 
 # model_list = [
 #     AutoModel.from_pretrained("DeepChem/ChemBERTa-77M-MTR"),
@@ -29,15 +29,19 @@ class Encoder:
     def tokenize(self, x: str) -> torch.Tensor:
         return self.tokenizer(x, return_tensors="pt", padding='max_length', truncation=True, max_length=512)
 
-    def __call__(self, tokens: str) -> torch.Tensor:
+    def __call__(self, tokens: Union[str, list[str], dict]) -> torch.Tensor:
+        if isinstance(tokens, str) or isinstance(tokens, list):
+            tokens = self.tokenize(tokens)
         return self.model(**tokens, output_hidden_states=True).hidden_states[-1]
     
 
 if __name__ == "__main__":
     smiles = Encoder()
     txt = Encoder(model_name = "allenai/scibert_scivocab_cased", model_type = BertForPreTraining)
-    test_txt = txt.tokenize(["To synthesize CCO, we need to do this and that"])
+    test_txt = "To synthesize CCO, we need to do this and that"
 
     smls = Encoder(model_name = "DeepChem/ChemBERTa-77M-MLM", model_type = AutoModelForMaskedLM)
     test_smls = smls.tokenize(["CCO"])
-    print(f"Txt encoder shape: {txt(test_txt).shape}\nSmiles encoder shape: {smls(test_smls).shape}")
+
+    print(f"Smiles encoder shape: {smls(test_smls).shape}")
+    print(f"Txt encoder shape: {txt(test_txt).shape}")

--- a/tests/test_Encoders.py
+++ b/tests/test_Encoders.py
@@ -1,26 +1,29 @@
 import sys
 sys.path.append(".")
 import chemspace as cs
-from transformers import BertForPreTraining
+from transformers import BertForPreTraining, AutoModelForMaskedLM
 
 import pytest
 import torch
 
 
 class TestEncoders:
-    @pytest.mark.parametrize('testSMILES',[['CCO'],['CCO','CCO']])
-    def test_sml_encoder_shape(self, testSMILES):
+    @pytest.mark.parametrize('testSMILES',['OCC', ['CCO'],['CCO','COC']])
+    @pytest.mark.parametrize('use_tokens',[True, False])
+    def test_sml_encoder_shape(self, testSMILES, use_tokens):
         """
         Test that the encoder returns the correct shape.
         Specifically for ChemBERTa-77M-MLM, the output dimension is 384.
 
         """
-        E = cs.Encoder(model_name = "DeepChem/ChemBERTa-77M-MLM")
-        batch_size = len(testSMILES)
-        test = E.tokenize(testSMILES)
-        assert E(test).shape == torch.Tensor(batch_size, 512, 384).shape
+        E = cs.Encoder(model_name = "DeepChem/ChemBERTa-77M-MLM", model_type=AutoModelForMaskedLM)
+        batch_size = len(testSMILES) if isinstance(testSMILES, list) else 1
+        if use_tokens:
+            testSMILES = E.tokenize(testSMILES)
+        assert E(testSMILES).shape == torch.Tensor(batch_size, 512, 384).shape
 
-    @pytest.mark.parametrize('testTXT',[['To synthesize CCO, we need to have the following'],['CCOHCOO is synthesized using the following chemicals']])
+    @pytest.mark.parametrize('testTXT',[['To synthesize CCO, we need to have the following'],
+                                        ['CCOHCOO is synthesized using the following chemicals', "CCOHCOO can also be synthesized using the following chemicals, but in a batch"]])
     def test_txt_encoder_shape(self, testTXT):
         """
         Test that the encoder returns the correct shape.


### PR DESCRIPTION
Allowed input either single strings, batch, or list of tokens to the Encoders.

An encoder internally can generate tokens if needed.
I am still unsure if it will cause an issue during the training. Hopefully, the gradients will be propagated nicely since we're not inputting strings in the training procedure.

This should only be used during inference.